### PR TITLE
add support for table names - multi-tenant setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [dbt package](https://docs.getdbt.com/docs/package-management):
 New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/).
 1. Include this package in your `packages.yml`
 2. Run `dbt deps`
-3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your jitsu pageviews table**.
+3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your table that includes pageviews**.
 
 ```YAML
 # dbt_project.yml
@@ -16,8 +16,9 @@ config-version: 2
 ...
 
 vars:
-  jitsu:
-     jitsu_events_table: "{{ source('jitsu', 'pageviews') }}" #or plane table path like database.schema.table_name
+  jitsu_events_table_prefix:    ##table name prefix
+  project_id:                ##suffix of table name. Handy if you have separate tables per tenant
+  jitsu_events_table_filter: "event_type='pageview'"      ## required if you have a single table for all events and only want to filter on pageviews
 
 ```
 
@@ -41,7 +42,7 @@ vars:
 ```
 5. Execute `dbt seed` -- this project includes a CSV that must be seeded for it
    the package to run successfully.
-6. Execute `dbt run` – the Jitsu Sessions models will get built
+6. Execute `dbt run --vars '{project_id: ''}' ` – the Jitsu Sessions models will get built
 
 ## Database support
 This package has been tested on

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,7 +26,25 @@ models:
   materialized: "{{var('jitsu_model_materialized', 'table')}}"
   pre-hook:
     - "{{ onrunstart() }}"   # On clickhouse enables allow_experimental_window_functions flag
-
+  jitsu:
+    sessions:
+      jitsu_events:
+        materialized: view
+        alias: "dbt_events_{{var('project_id')}}"
+      jitsu_events_plus_session_id:
+        alias: "dbt_events_plus_session_id_{{var('project_id')}}"
+        unique_key: 'event_id'
+        sort: '_timestamp'
+        dist: 'event_id' 
+      jitsu_sessions:
+        alias: "dbt_sessions_{{var('project_id')}}"
+        unique_key: 'session_id'
+        sort: 'session_start_timestamp'
+        dist: 'session_id'
+      jitsu_sessions_with_count:
+        alias: "dbt_sessions_wth_count_{{var('project_id')}}"
+        materialized: view
+      
 
 dispatch:
   - macro_namespace: dbt_utils
@@ -34,7 +52,9 @@ dispatch:
 
 vars:
   # location of source data table
-  jitsu_events_table: "{{ source('jitsu', 'pageviews') }}" 
+  jitsu_events_table_prefix: 'um_eventnative.events_'
+  project_id: umolo8eeaz
+  jitsu_events_table: "{{var('jitsu_events_table_prefix')}}{{var('project_id')}}"
 
   # length of trailing window in minutes for session attribution.
   # We recommend enabling builtin Retrospective User Recognition feature for user stitching

--- a/models/sessions/jitsu_events.sql
+++ b/models/sessions/jitsu_events.sql
@@ -1,7 +1,4 @@
-{{ config(
-    materialized = 'view'
-    )}}
-{% if var('jitsu_events_table') is defined %}
+{% if var('jitsu_events_table_filter') is defined %}
     select * from {{var('jitsu_events_table')}} where user_anonymous_id is not null and {{var('jitsu_events_table_filter')}}
 {% else %}
     select * from {{var('jitsu_events_table')}} where user_anonymous_id is not null

--- a/models/sessions/jitsu_events_plus_session_id.sql
+++ b/models/sessions/jitsu_events_plus_session_id.sql
@@ -1,10 +1,3 @@
-{{ config(
-    unique_key = 'eventn_ctx_event_id',
-    sort = '_timestamp',
-    dist = 'eventn_ctx_event_id',
-    )}}
-
-
 with pageviews as (
 
     select * from {{ref('jitsu_events')}}

--- a/models/sessions/jitsu_sessions.sql
+++ b/models/sessions/jitsu_sessions.sql
@@ -1,9 +1,3 @@
-{{ config(
-    unique_key = 'session_id',
-    sort = 'session_start_timestamp',
-    dist = 'session_id',
-    )}}
-
 {% set partition_by = "partition by session_id" %}
 
 {% set window_clause = "

--- a/models/sessions/jitsu_sessions_with_count.sql
+++ b/models/sessions/jitsu_sessions_with_count.sql
@@ -1,7 +1,3 @@
-{{ config(
-    materialized = 'view'
-    )}}
-
 select * ,
        row_number() over (
             partition by blended_user_id

--- a/models/sessions/schema.yml
+++ b/models/sessions/schema.yml
@@ -7,7 +7,7 @@ models:
       - name: user_anonymous_id
         tests:
           - not_null
-      - name: eventn_ctx_event_id
+      - name: event_id
         tests:
           - unique
           - not_null
@@ -15,7 +15,7 @@ models:
   - name: jitsu_events_plus_session_id
     description: "{{doc('jitsu_events_plus_session_id')}}"
     columns:
-      - name: eventn_ctx_event_id
+      - name: event_id
         tests:
           - unique
           - not_null


### PR DESCRIPTION
- added support for alias table names based on main events table suffix. Support for multi tenancy, separate tables for different tentants.
- moved model config to dbt_project.yml
- changed unique_key from eventn_ctx_event_id to event_id